### PR TITLE
fix the downloaded version of SDP to avoid error along with SDP updat…

### DIFF
--- a/templates/PerforceServerSetupTemplate.yaml
+++ b/templates/PerforceServerSetupTemplate.yaml
@@ -260,7 +260,7 @@ Resources:
               ignoreErrors: false
         04_config_install_sdp:
           sources:
-            /tmp: "https://swarm.workshop.perforce.com/projects/perforce-software-sdp/download/downloads/sdp.Unix.tgz"
+            /tmp: "https://swarm.workshop.perforce.com/downloads/guest/perforce_software/sdp/downloads/sdp.Unix.tgz?v=%2314"
           commands:
             01_mv_sdp:
               command: "mv /tmp/sdp /hxdepots"


### PR DESCRIPTION
…es later than v2020.1

*Issue #, if available:*

*Description of changes:*
As per https://github.com/aws-samples/aws-perforce/issues/1, the template uses a fixed version for SDP instead of downloading the latest version. Here is the fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
